### PR TITLE
Ability to use multiline requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ bar.css
 
 ## Write less, do more
 You also need know, that all examples above uses ``requires: foo.js``, but you can also use it without trailing "s", like ``require: foo.js`` or even without colon like ``requires foo.js`` or ``require foo.js``.
+And, of course, in multi-line style you can use spaces to indent your dependencies, like:
+```javascript
+/* require
+  foo/bar.js
+      bar/foo.js
+*/
+```
+All of those spaces will be cleaned and dependencies are processed correctly.
 
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,64 @@
+Gulp DepOrder plugin
+====================
 
-## Usage
+This plugin will reorder JavaScript or CSS files in the stream based on comments at the top of files.
+This is useful for automatically ordering files before concatenating them without a full-blown dependency system like requirejs.
 
+The plugin attempts to reorder as little as possible so you can manually order large sets of
+files and only use the comments to fine tune.
+
+# How to use
+
+## Gulp
+For JavaScript files:
 ```javascript
 var deporder = require('gulp-deporder');
 var concat   = require('gulp-concat');
 
 gulp.task('scripts', function() {
-  gulp.src('./lib/*.js')
-    .pipe(deporder())
-    .pipe(concat('all.js'))
-    .pipe(gulp.dest('./dist/'))
-});
-```
-
-This will reorder Javascript files in the stream based on comments at the top of files in the
-form ``// requires: file1 file2``. This is useful for automatically ordering files before
-concatenating them without a full-blown dependency system like requirejs.
-
-The plugin attempts to reorder as little as possible so you can manually order large sets of
-files and only use the comments to fine tune:
-
-```javascript
-gulp.task('scripts', function() {
-    return gulp.src(['./models/*.js',
-                     './collections/*.js',
-                     './views/*.js'])
+    return gulp.src('./lib/*.js')
         .pipe(deporder())
         .pipe(concat('all.js'))
         .pipe(gulp.dest('./dist/'))
 });
 ```
 
-## LICENSE
+For CSS files:
+```javascript
+gulp.task('styles', function() {
+    return gulp.src('./lib/*.css')
+        .pipe(deporder())
+        .pipe(concat('all.css'))
+        .pipe(gulp.dest('./dist/'))
+});
+```
+
+## JavaScript
+
+There is several ways to specify dependencies:
+First is single-line:
+``// requires: foo.js bar.js``
+Second is multi-line if you have lot of dependencies:
+```javascript
+/* requires:
+foo.js
+bar.js
+*/
+```
+
+## CSS
+Since CSS doesn't support single-line comments, you should only use multi-line comments:
+```css
+/* requires:
+foo.css
+bar.css
+*/
+```
+
+##
+You also need know, that all examples above uses ``requires: foo.js``, but you can also use it without trailing "s", like ``require: foo.js`` or even without without colon like ``requires foo.js`` or ``require foo.js``
+
+# LICENSE
 
 (MIT License)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ files and only use the comments to fine tune.
 
 # How to use
 
-## Gulp
+### Gulp
 For JavaScript files:
 ```javascript
 var deporder = require('gulp-deporder');
@@ -33,7 +33,7 @@ gulp.task('styles', function() {
 });
 ```
 
-## JavaScript
+### JavaScript
 
 There is several ways to specify dependencies:
 First is single-line:
@@ -46,7 +46,7 @@ bar.js
 */
 ```
 
-## CSS
+### CSS
 Since CSS doesn't support single-line comments, you should only use multi-line comments:
 ```css
 /* requires:
@@ -55,8 +55,8 @@ bar.css
 */
 ```
 
-##
-You also need know, that all examples above uses ``requires: foo.js``, but you can also use it without trailing "s", like ``require: foo.js`` or even without without colon like ``requires foo.js`` or ``require foo.js``
+## Write less, do more
+You also need know, that all examples above uses ``requires: foo.js``, but you can also use it without trailing "s", like ``require: foo.js`` or even without colon like ``requires foo.js`` or ``require foo.js``.
 
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ files and only use the comments to fine tune.
 For JavaScript files:
 ```javascript
 var deporder = require('gulp-deporder');
-var concat   = require('gulp-concat');
+var concat = require('gulp-concat');
 
 gulp.task('scripts', function() {
     return gulp.src('./lib/*.js')
@@ -25,6 +25,9 @@ gulp.task('scripts', function() {
 
 For CSS files:
 ```javascript
+var deporder = require('gulp-deporder');
+var concat = require('gulp-concat');
+
 gulp.task('styles', function() {
     return gulp.src('./lib/*.css')
         .pipe(deporder())

--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ module.exports = function() {
         }
     }
 
-    var reInlineDependencies = /^\s*\/\/\s*require(?:s)?:\s+(.*)$/m;
-    var reMultilineDependencies = /(\/\*\s*require(?:s)?([\s\S]*?)\*\/)/m;
+    var reInlineDependencies = /^\s*\/\/\s*require(?:s)?(?:\:)?:\s+(.*)$/m;
+    var reMultilineDependencies = /(\/\*\s*require(?:s)?(?:\:)?([\s\S]*?)\*\/)/m;
 
     function getRequired(file) {
         // Accepts a vinyl file object and searches it for dependencies.

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function() {
         }
     }
 
-    var reInlineDependencies = /^\s*\/\/\s*require(?:s)?(?:\:)?:\s+(.*)$/m;
+    var reInlineDependencies = /^\s*\/\/\s*require(?:s)?(?:\:)?\s+(.*)$/m;
     var reMultilineDependencies = /(\/\*\s*require(?:s)?(?:\:)?([\s\S]*?)\*\/)/m;
 
     function getRequired(file) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ module.exports = function() {
         }
     }
 
-    var reDependencies = /^\s*\/\/\s*require(?:s)?:\s+(.*)$/m;
+    var reInlineDependencies = /^\s*\/\/\s*require(?:s)?:\s+(.*)$/m;
+    var reMultilineDependencies = /(\/\*\s*require(?:s)?([\s\S]*?)\*\/)/m;
 
     function getRequired(file) {
         // Accepts a vinyl file object and searches it for dependencies.
@@ -48,9 +49,15 @@ module.exports = function() {
 
         if (file.contents) {
             var contents = file.contents.toString('utf8', 0, 1024);
-            var match = reDependencies.exec(contents);
+            var match = reInlineDependencies.exec(contents);
             if (match) {
                 result.requires = match[1].split(/\s+/);
+            }
+
+            match = reMultilineDependencies.exec(contents);
+            if (match && match[2]) {
+                match[2] = match[2].replace(/\r|\n/g, ' ').replace(/\s+/g, ' ').trim(' ');
+                result.requires = result.requires.concat(match[2].split(/\s+/));
             }
         }
 

--- a/test/main.js
+++ b/test/main.js
@@ -6,71 +6,153 @@ require('mocha');
 
 describe('gulp-deporder', function() {
     describe('deporder()', function() {
-
         it('should be stable', function(done) {
-            var stream = deporder();
-
-            var before   = ['arkstream.js', 'blackpearl.js', 'chimneypool.js'].map(makeFile);
-            var expected = ['arkstream.js', 'blackpearl.js', 'chimneypool.js'];
-
-            var result = [];
-            stream.on('data', function(f) {
-                result.push(f.relative);
+            generateTest({
+                before: [
+                    'arkstream.js',
+                    'blackpearl.js',
+                    'chimneypool.js'
+                ],
+                expected: [
+                    'arkstream.js',
+                    'blackpearl.js',
+                    'chimneypool.js'
+                ],
+                onEnd: function() {
+                    assert.deepEqual(this.test.result, this.test.expected);
+                    done();
+                }
             });
-
-            stream.on('end', function() {
-                assert.deepEqual(result, expected);
-                done();
-            });
-
-            before.forEach(stream.write);
-            stream.end();
         });
 
-        it('should reorder', function(done) {
-
-            var stream = deporder();
-
-            var before   = [ 'arkstream.js  --> chimneypool.js blackpearl.js',
-                             'blackpearl.js --> chimneypool.js',
-                             'chimneypool.js' 
-                           ].map(makeFile);
-            var expected = [ 'chimneypool.js', 'blackpearl.js', 'arkstream.js' ];
-
-            var result = [];
-            stream.on('data', function(f) { result.push(f.relative); });
-
-            stream.on('end', function() {
-                assert.deepEqual(result, expected);
-                done();
+        it('should reorder - inline without colon', function(done) {
+            generateTest({
+                before: [
+                    'arkstream.js  --> chimneypool.js blackpearl.js',
+                    'blackpearl.js --> chimneypool.js',
+                    'chimneypool.js'
+                ],
+                expected: [
+                    'chimneypool.js',
+                    'blackpearl.js',
+                    'arkstream.js'
+                ],
+                onEnd: function() {
+                    assert.deepEqual(this.test.result, this.test.expected);
+                    done();
+                }
             });
+        });
 
-            before.forEach(stream.write);
-            stream.end();
+        it('should reorder - inline with colon', function(done) {
+            generateTest({
+                module: {
+                    colon: true
+                },
+                before: [
+                    'arkstream.js  --> chimneypool.js blackpearl.js',
+                    'blackpearl.js --> chimneypool.js',
+                    'chimneypool.js'
+                ],
+                expected: [
+                    'chimneypool.js',
+                    'blackpearl.js',
+                    'arkstream.js'
+                ],
+                onEnd: function() {
+                    assert.deepEqual(this.test.result, this.test.expected);
+                    done();
+                }
+            });
+        });
+
+        it('should reorder - multiline without colon', function(done) {
+            generateTest({
+                module: {
+                    multiline: true
+                },
+                before: [
+                    'arkstream.js  --> chimneypool.js blackpearl.js',
+                    'blackpearl.js --> chimneypool.js',
+                    'chimneypool.js'
+                ],
+                expected: [
+                    'chimneypool.js',
+                    'blackpearl.js',
+                    'arkstream.js'
+                ],
+                onEnd: function() {
+                    assert.deepEqual(this.test.result, this.test.expected);
+                    done();
+                }
+            });
+        });
+
+        it('should reorder - multiline with colon', function(done) {
+            generateTest({
+                module: {
+                    multiline: true,
+                    colon: true
+                },
+                before: [
+                    'arkstream.js  --> chimneypool.js blackpearl.js',
+                    'blackpearl.js --> chimneypool.js',
+                    'chimneypool.js'
+                ],
+                expected: [
+                    'chimneypool.js',
+                    'blackpearl.js',
+                    'arkstream.js'
+                ],
+                onEnd: function() {
+                    assert.deepEqual(this.test.result, this.test.expected);
+                    done();
+                }
+            });
         });
 
         it('should report errors', function(done) {
-
-            var stream = deporder();
-
-            var before   = [ 'arkstream.js  --> chimneypool.js blackpearl.js',
-                             'blackpearl.js --> danderspritz.js',
-                             'chimneypool.js' 
-                           ].map(makeFile);
-
-            var result = [];
-            stream.on('data', function(f) { result.push(f.relative); });
-
-            stream.on('error', function(e) { 
-                done();
+            generateTest({
+                before: [
+                    'arkstream.js  --> chimneypool.js blackpearl.js',
+                    'blackpearl.js --> danderspritz.js',
+                    'chimneypool.js'
+                ],
+                onError: function(e) {
+                    done();
+                }
             });
-
-            before.forEach(stream.write);
-            stream.end();
         });
     });
 
-    function makeFile(spec) {
+    function generateTest(options)
+    {
+        var stream = deporder();
+        var before = options.before.map(makeFile, options.module);
+        var result = [];
+
+        stream.on('data', function(file) {
+            result.push(file.relative);
+        });
+
+        stream.test = {
+            result: result,
+            expected: options.expected
+        };
+
+        if (options.onError) {
+            stream.on('error', options.onError);
+        }
+
+        if (options.onEnd) {
+            stream.on('end', options.onEnd);
+        }
+
+        before.forEach(stream.write);
+        stream.end();
+    }
+
+    function makeFile(spec, options) {
         var filename;
         var dir = '/mkultra';
         var contents = 'Hello, Sailor!';
@@ -78,7 +160,7 @@ describe('gulp-deporder', function() {
         var match = /^(\S+)\s+-->\s+(.*)$/.exec(spec);
         if (match) {
             filename = match[1];
-            contents = '\n // requires: ' + match[2] + '\n' + contents;
+            contents = generateRequires(match[2].split(' '), options) + '\n' + contents;
         } else {
             filename = spec;
         }
@@ -89,5 +171,23 @@ describe('gulp-deporder', function() {
             path: path.join(dir, filename),
             contents: new Buffer(contents)
         });
+    }
+
+    function generateRequires(dependencies, options)
+    {
+        options = options || {};
+
+        var content = 'requires';
+        if (options.colon) {
+            content += ':';
+        }
+
+        if (options.multiline) {
+            content = '/* \n' + content + '\n ' + dependencies.join('\n ') + '\n*/';
+        } else {
+            content = '// ' + content + ' ' + dependencies.join(' ');
+        }
+
+        return content;
     }
 });


### PR DESCRIPTION
First of all it's very uncomfortable to manage more than two-three requires in one line, so added ability to use requires like
```
/* require:
dep1.js
dep2.js
dep3.js
*/
```
It also doesn't matter how many spaces entered before and after file name.
Second ability is don't write colon, e.g. `// require: dep.js` -> `// require dep.js`
_Should reorder_ test was updated to match all cases.