### PR TITLE
remove gulp-util deprecated dependency, add  plugin-error and vinyl

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,9 @@
 /* jshint node: true */
 
 var through = require('through');
-var gutil = require('gulp-util');
 var path = require('path');
-var PluginError = gutil.PluginError;
-var File = gutil.File;
+var PluginError = require('plugin-error');
+var File = require('vinyl');
 
 module.exports = function() {
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "test": "mocha"
   },
   "dependencies": {
+    "path": "^0.12.7",
+    "plugin-error": "^1.0.1",
     "through": "~2.3.4",
-    "gulp-util": "~2.2.14",
-    "path": "^0.12.7"
+    "vinyl": "^2.2.0"
   },
   "devDependencies": {
     "mocha": "*"

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,6 @@
 var deporder = require('../');
 var path = require('path');
-var File = require('gulp-util').File;
+var File = require('vinyl');
 var assert = require('assert');
 require('mocha');
 


### PR DESCRIPTION

`gulp-util` module has been deprecated. More information at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

I've made changes to use instead:
`gutil.File` => https://www.npmjs.com/package/vinyl
`gutil.PluginError` => https://www.npmjs.com/package/plugin-error

All 6 tests pass.